### PR TITLE
Create tag on merge to release branch

### DIFF
--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -17,7 +17,7 @@ jobs:
         composer install --no-dev -o
     - name: Setup
       run: |
-        VERSION=$(cat README.md| grep 'Stable tag:' | awk '{print $3}')
+        VERSION=$(cat README.MD| grep 'Stable tag:' | awk '{print $3}')
         [[ "$VERSION" != "" ]] || exit 1
         echo "VERSION=$VERSION" >> $GITHUB_ENV
 

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -31,6 +31,6 @@ jobs:
         git add -f vendor/*
         git commit -m "Release $VERSION"
         git tag "$VERSION"
-        git push --tags
+      #  git push --tags
       # env:
       #   TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -5,8 +5,8 @@ on:
       - 'release'
 
 jobs:
-  wordpress:
-    name: Release
+  tag:
+    name: Tag with Assets
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -31,6 +31,4 @@ jobs:
         git add -f vendor/*
         git commit -m "Release $VERSION"
         git tag "$VERSION"
-      #  git push --tags
-      # env:
-      #   TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        git push --tags

--- a/.github/workflows/build-tag.yml
+++ b/.github/workflows/build-tag.yml
@@ -1,0 +1,36 @@
+name: Build and Tag
+on:
+  push:
+    branches:
+      - 'release'
+
+jobs:
+  wordpress:
+    name: Release
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Build
+      run: |
+        composer install --no-dev -o
+    - name: Setup
+      run: |
+        VERSION=$(cat README.md| grep 'Stable tag:' | awk '{print $3}')
+        [[ "$VERSION" != "" ]] || exit 1
+        echo "VERSION=$VERSION" >> $GITHUB_ENV
+
+    - name: Tag
+      run: |
+        echo "Releasing version $VERSION ..."
+        [[ "$VERSION" != "" ]] || exit 1
+        git config user.name Pantheon Automation
+        git config user.email bot@getpantheon.com
+        git checkout -b "robot-release-$VERSION"
+        git add -f vendor/*
+        git commit -m "Release $VERSION"
+        git tag "$VERSION"
+        git push --tags
+      # env:
+      #   TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/reelase-to-dot-org.yml
+++ b/.github/workflows/reelase-to-dot-org.yml
@@ -6,12 +6,12 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - name: Bail Out! # remove this step to actually deploy to wp.org
-        run: exit 1
-      - uses: actions/checkout@v2
-      - name: WordPress Plugin Deploy
-        uses: 10up/action-wordpress-plugin-deploy@2.1.1
-        env:
-          SVN_USERNAME: ${{ secrets.WPORG_USERNAME }}
-          SVN_PASSWORD: ${{ secrets.WPORG_PASSWORD }}
-          SLUG: rossums-universal-robots
+      - name: Deploy!
+        run: exit 0
+      # - uses: actions/checkout@v2
+      # - name: WordPress Plugin Deploy
+      #   uses: 10up/action-wordpress-plugin-deploy@2.1.1
+      #   env:
+      #     SVN_USERNAME: ${{ secrets.WPORG_USERNAME }}
+      #     SVN_PASSWORD: ${{ secrets.WPORG_PASSWORD }}
+      #     SLUG: rossums-universal-robots

--- a/README.MD
+++ b/README.MD
@@ -5,7 +5,7 @@ Tags: comments, spam
 Requires at least: 4.5  
 Tested up to: 6.2.1  
 Requires PHP: 5.6  
-Stable tag: 0.1.0-dev  
+Stable tag: 0.1.0.1  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html 
 

--- a/README.MD
+++ b/README.MD
@@ -5,7 +5,7 @@ Tags: comments, spam
 Requires at least: 4.5  
 Tested up to: 6.2.1  
 Requires PHP: 5.6  
-Stable tag: 0.1.0.1  
+Stable tag: 0.1.0-dev  
 License: GPLv2 or later  
 License URI: https://www.gnu.org/licenses/gpl-2.0.html 
 


### PR DESCRIPTION
On commits to `release`, tag a version with built assets included in preparation for creating a release.

Modeled after https://github.com/pantheon-systems/wp-saml-auth/

Tested pushing directly to release branch here: https://github.com/pantheon-systems/plugin-pipeline-example/actions/runs/5152587108/jobs/9278844926 (I deleted the tag after verifying in github UI)