### PR TITLE
Add wporg code analysis

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pantheon-systems/plugin-pipeline-example
-          ref: $GITHUB_REF
         run: ls $(pwd)
       - name: WP.org Code Analysis
         run: |

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -43,9 +43,8 @@ jobs:
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)
-          ls $path
-          echo "WP.org Code Analysis is installed to /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis. cd'ing there..."
-          cd /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis
+          echo "WP.org Code Analysis is installed to ${path}/wporg-code-analysis. cd'ing there..."
+          cd ${path}/wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n
           vendor/bin/phpcs -s -v --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* --report=summary $path

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -47,7 +47,7 @@ jobs:
           cd ${path}/wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n
-          vendor/bin/phpcs -s -v --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* --report=summary $path
+          vendor/bin/phpcs -s --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* --report=summary $path
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -42,7 +42,6 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pantheon-systems/plugin-pipeline-example
-        run: ls $(pwd)
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -45,10 +45,8 @@ jobs:
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)
-          ls $path
-          ls ../
-          exit 1
-          cd wporg-code-analysis
+          echo "WP.org Code Analysis is installed to /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis. cd'ing there..."
+          cd /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n
           vendor/bin/phpcs -s -v --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* --report=summary $path

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -44,7 +44,7 @@ jobs:
           echo "Setting up WP.org Code Analysis"
           composer install
           echo "Running bash ./bin/scan-dir.sh -ns ${{ github.workspace }}"
-          vendor/bin/phpcs  -s --standard=./MinimalPluginStandard ${{ github.workspace }}
+          vendor/bin/phpcs  -s --standard=./MinimalPluginStandard ${{ github.workspace }} --ignore=wporg-code-analysis/*
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -44,7 +44,7 @@ jobs:
           echo "Setting up WP.org Code Analysis"
           composer install
           echo "Running bash ./bin/scan-dir.sh -ns ${{ github.workspace }}"
-          bash ./bin/scan-dir.sh -ns ${{ github.workspace }}
+          vendor/bin/phpcs  -s --standard=./MinimalPluginStandard ${{ github.workspace }}
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -38,6 +38,8 @@ jobs:
           repository: WordPress/wporg-code-analysis
           ref: trunk
           path: wporg-code-analysis
+      - name: Checkout Plugin
+        uses: actions/checkout@v3
         with:
           repository: pantheon-systems/plugin-pipeline-example
           ref: $GITHUB_REF

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -38,6 +38,9 @@ jobs:
           repository: WordPress/wporg-code-analysis
           ref: trunk
           path: wporg-code-analysis
+        with:
+          repository: pantheon-systems/plugin-pipeline-example
+          ref: $GITHUB_REF
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)
-          ls /home/runner/work/plugin-pipeline-example/
+          ls /home/runner/work/plugin-pipeline-example/plugin-pipeline-example
           echo "WP.org Code Analysis is installed to /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis. cd'ing there..."
           cd /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis
           echo "Setting up WP.org Code Analysis"

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -46,7 +46,7 @@ jobs:
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)
-          ls /home/runner/work
+          ls /home/runner/work/plugin-pipeline-example/
           echo "WP.org Code Analysis is installed to /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis. cd'ing there..."
           cd /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis
           echo "Setting up WP.org Code Analysis"

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -41,7 +41,9 @@ jobs:
       - name: WP.org Code Analysis
         run: |
           cd wporg-code-analysis
+          echo "Setting up WP.org Code Analysis"
           composer install
+          echo "Running bash ./bin/scan-dir.sh -ns ${{ github.workspace }}"
           bash ./bin/scan-dir.sh -ns ${{ github.workspace }}
   phpcompatibility:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -42,7 +42,7 @@ jobs:
         run: |
           cd wporg-code-analysis
           composer install
-          ./bin/scan-dir.sh -ns ${{ github.workspace }}
+          bash ./bin/scan-dir.sh -ns ${{ github.workspace }}
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -42,9 +42,7 @@ jobs:
         run: |
           cd wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
-          composer install
-          echo "Running bash ./bin/scan-dir.sh -ns ${{ github.workspace }}"
-          vendor/bin/phpcs  -s --standard=./MinimalPluginStandard ${{ github.workspace }} --ignore=wporg-code-analysis/*
+          composer install -n
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -32,21 +32,18 @@ jobs:
     runs-on: ubuntu-latest
     name: WP.org Code Analysis
     steps:
+      - name: Checkout Plugin
+        uses: actions/checkout@v3
       - name: Checkout WP.org Code Analysis
         uses: actions/checkout@v3
         with:
           repository: WordPress/wporg-code-analysis
           ref: trunk
           path: wporg-code-analysis
-      - name: Checkout Plugin
-        uses: actions/checkout@v3
-        with:
-          repository: pantheon-systems/plugin-pipeline-example
-          ref: ${{ github.event.pull_request.head.sha }}
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)
-          ls /home/runner/work/plugin-pipeline-example/plugin-pipeline-example
+          ls $path
           echo "WP.org Code Analysis is installed to /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis. cd'ing there..."
           cd /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis
           echo "Setting up WP.org Code Analysis"

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -47,6 +47,7 @@ jobs:
           path=$(pwd)
           ls $path
           ls ../
+          exit 1
           cd wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -34,9 +34,12 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repository: WordPress/wporg-code-analysis
+          ref: trunk
+          path: wporg-code-analysis
       - name: WP.org Code Analysis
         run: |
-          git clone git@github.com:WordPress/wporg-code-analysis.git
           cd wporg-code-analysis
           composer install
           ./bin/scan-dir.sh -ns ${{ github.workspace }}

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -46,6 +46,7 @@ jobs:
         run: |
           path=$(pwd)
           ls $path
+          ls ../
           cd wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -43,6 +43,7 @@ jobs:
         with:
           repository: pantheon-systems/plugin-pipeline-example
           ref: $GITHUB_REF
+        run: ls $(pwd)
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -28,6 +28,18 @@ jobs:
         run: composer lint
       - name: Run tests
         run: composer test
+  wporg-code-analysis:
+    runs-on: ubuntu-latest
+    name: WP.org Code Analysis
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+      - name: WP.org Code Analysis
+        run: |
+          git clone git@github.com:WordPress/wporg-code-analysis.git
+          cd wporg-code-analysis
+          composer install
+          ./bin/scan-dir.sh -ns ${{ github.workspace }}
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility
@@ -37,7 +49,7 @@ jobs:
       - run: echo "Note these tests may be incomplete for newer PHP version and miss some deprecations"
         shell: bash
       - name: PHPCompatibility
-        # using @dev because PHPCompatibility ^9 does not yet have the 
+        # using @dev because PHPCompatibility ^9 does not yet have the
         # sniffers for 8.0+ but main branch does
         uses: pantheon-systems/phpcompatibility-action@dev
         with:

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -42,6 +42,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           repository: pantheon-systems/plugin-pipeline-example
+          ref: ${{ github.event.pull_request.head.sha }}
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -41,6 +41,7 @@ jobs:
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)
+          ls $path
           cd wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -40,10 +40,11 @@ jobs:
           path: wporg-code-analysis
       - name: WP.org Code Analysis
         run: |
+          path=$(pwd)
           cd wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n
-          vendor/bin/phpcs -s --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* --report=summary ../
+          vendor/bin/phpcs -s -v --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* --report=summary $path
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -47,6 +47,7 @@ jobs:
           cd ${path}/wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n
+          echo "Running WP.org Code Analysis"
           vendor/bin/phpcs -s --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* $path
   phpcompatibility:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     name: WP.org Code Analysis
     steps:
-      - name: Checkout
+      - name: Checkout WP.org Code Analysis
         uses: actions/checkout@v3
         with:
           repository: WordPress/wporg-code-analysis

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -43,6 +43,7 @@ jobs:
           cd wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n
+          vendor/bin/phpcs -s --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* --report=summary ../
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -46,6 +46,7 @@ jobs:
       - name: WP.org Code Analysis
         run: |
           path=$(pwd)
+          ls /home/runner/work
           echo "WP.org Code Analysis is installed to /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis. cd'ing there..."
           cd /home/runner/work/plugin-pipeline-example/plugin-pipeline-example/wporg-code-analysis
           echo "Setting up WP.org Code Analysis"

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -47,7 +47,7 @@ jobs:
           cd ${path}/wporg-code-analysis
           echo "Setting up WP.org Code Analysis"
           composer install -n
-          vendor/bin/phpcs -s --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* --report=summary $path
+          vendor/bin/phpcs -s --standard=MinimalPluginStandard --ignore=wporg-code-analysis/* $path
   phpcompatibility:
     runs-on: ubuntu-latest
     name: PHP Compatibility

--- a/composer.json
+++ b/composer.json
@@ -1,34 +1,36 @@
 {
-    "name": "pantheon-systems/rossums-universal-robots",
-    "description": "A demo plugin to test and showcase github actions during plugin development and release",
-    "type": "wordpress-plugin",
-    "license": "MIT",
-    "authors": [
-        {
-            "name": "CMS PLatform",
-            "email": "cms-platform@pantheon.io"
-        }
-    ],
-    "require-dev": {
-        "pantheon-systems/pantheon-wp-coding-standards": "^1.0",
-        "pantheon-systems/pantheon-wordpress-upstream-tests": "dev-master",
-        "phpunit/phpunit": "^9",
-        "yoast/phpunit-polyfills": "^1.0"
-      },
-      "scripts": {
-        "lint": [
-          "@phpcs",
-          "@jshint"
-        ],
-        "jshint": "npm run lint:js",
-        "phpcs": "vendor/bin/phpcs",
-        "phpcbf": "vendor/bin/phpcbf",
-        "phpunit": "vendor/bin/phpunit",
-        "test": "@phpunit"
-      },
-      "config": {
-        "allow-plugins": {
-          "dealerdirect/phpcodesniffer-composer-installer": true
-        }
+  "name": "pantheon-systems/rossums-universal-robots",
+  "description": "A demo plugin to test and showcase github actions during plugin development and release",
+  "type": "wordpress-plugin",
+  "license": "MIT",
+  "minimum-stability": "dev",
+  "prefer-stable": true,
+  "authors": [
+      {
+          "name": "CMS PLatform",
+          "email": "cms-platform@pantheon.io"
       }
+  ],
+  "require-dev": {
+      "pantheon-systems/pantheon-wp-coding-standards": "^1.0",
+      "pantheon-systems/pantheon-wordpress-upstream-tests": "dev-master",
+      "phpunit/phpunit": "^9",
+      "yoast/phpunit-polyfills": "^1.0"
+  },
+  "scripts": {
+    "lint": [
+      "@phpcs",
+      "@jshint"
+    ],
+    "jshint": "npm run lint:js",
+    "phpcs": "vendor/bin/phpcs -s .",
+    "phpcbf": "vendor/bin/phpcbf",
+    "phpunit": "vendor/bin/phpunit",
+    "test": "@phpunit"
+  },
+  "config": {
+    "allow-plugins": {
+      "dealerdirect/phpcodesniffer-composer-installer": true
+    }
+  }
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c4931f9cb6bc4a73be9c6fe4c01988c3",
+    "content-hash": "917e9fd41f1c49a8f5e64fafe71ef856",
     "packages": [],
     "packages-dev": [
         {
@@ -583,30 +583,30 @@
         },
         {
             "name": "doctrine/instantiator",
-            "version": "2.0.0",
+            "version": "1.5.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/doctrine/instantiator.git",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0"
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
-                "reference": "c6222283fa3f4ac679f8b9ced9a4e23f163e80d0",
+                "url": "https://api.github.com/repos/doctrine/instantiator/zipball/0a0fa9780f5d4e507415a065172d26a98d02047b",
+                "reference": "0a0fa9780f5d4e507415a065172d26a98d02047b",
                 "shasum": ""
             },
             "require": {
-                "php": "^8.1"
+                "php": "^7.1 || ^8.0"
             },
             "require-dev": {
-                "doctrine/coding-standard": "^11",
+                "doctrine/coding-standard": "^9 || ^11",
                 "ext-pdo": "*",
                 "ext-phar": "*",
-                "phpbench/phpbench": "^1.2",
-                "phpstan/phpstan": "^1.9.4",
-                "phpstan/phpstan-phpunit": "^1.3",
-                "phpunit/phpunit": "^9.5.27",
-                "vimeo/psalm": "^5.4"
+                "phpbench/phpbench": "^0.16 || ^1",
+                "phpstan/phpstan": "^1.4",
+                "phpstan/phpstan-phpunit": "^1",
+                "phpunit/phpunit": "^7.5 || ^8.5 || ^9.5",
+                "vimeo/psalm": "^4.30 || ^5.4"
             },
             "type": "library",
             "autoload": {
@@ -633,7 +633,7 @@
             ],
             "support": {
                 "issues": "https://github.com/doctrine/instantiator/issues",
-                "source": "https://github.com/doctrine/instantiator/tree/2.0.0"
+                "source": "https://github.com/doctrine/instantiator/tree/1.5.0"
             },
             "funding": [
                 {
@@ -649,7 +649,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-12-30T00:23:10+00:00"
+            "time": "2022-12-30T00:15:36+00:00"
         },
         {
             "name": "fabpot/goutte",
@@ -884,16 +884,16 @@
         },
         {
             "name": "guzzlehttp/promises",
-            "version": "1.5.2",
+            "version": "1.5.3",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/promises.git",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598"
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/promises/zipball/b94b2807d85443f9719887892882d0329d1e2598",
-                "reference": "b94b2807d85443f9719887892882d0329d1e2598",
+                "url": "https://api.github.com/repos/guzzle/promises/zipball/67ab6e18aaa14d753cc148911d273f6e6cb6721e",
+                "reference": "67ab6e18aaa14d753cc148911d273f6e6cb6721e",
                 "shasum": ""
             },
             "require": {
@@ -903,11 +903,6 @@
                 "symfony/phpunit-bridge": "^4.4 || ^5.1"
             },
             "type": "library",
-            "extra": {
-                "branch-alias": {
-                    "dev-master": "1.5-dev"
-                }
-            },
             "autoload": {
                 "files": [
                     "src/functions_include.php"
@@ -948,7 +943,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/promises/issues",
-                "source": "https://github.com/guzzle/promises/tree/1.5.2"
+                "source": "https://github.com/guzzle/promises/tree/1.5.3"
             },
             "funding": [
                 {
@@ -964,7 +959,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-28T14:55:35+00:00"
+            "time": "2023-05-21T12:31:43+00:00"
         },
         {
             "name": "guzzlehttp/psr7",
@@ -1132,16 +1127,16 @@
         },
         {
             "name": "nikic/php-parser",
-            "version": "v4.15.4",
+            "version": "v4.15.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nikic/PHP-Parser.git",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290"
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
-                "reference": "6bb5176bc4af8bcb7d926f88718db9b96a2d4290",
+                "url": "https://api.github.com/repos/nikic/PHP-Parser/zipball/11e2663a5bc9db5d714eedb4277ee300403b4a9e",
+                "reference": "11e2663a5bc9db5d714eedb4277ee300403b4a9e",
                 "shasum": ""
             },
             "require": {
@@ -1182,9 +1177,9 @@
             ],
             "support": {
                 "issues": "https://github.com/nikic/PHP-Parser/issues",
-                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.4"
+                "source": "https://github.com/nikic/PHP-Parser/tree/v4.15.5"
             },
-            "time": "2023-03-05T19:49:14+00:00"
+            "time": "2023-05-19T20:20:00+00:00"
         },
         {
             "name": "pantheon-systems/pantheon-wordpress-upstream-tests",
@@ -3567,16 +3562,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v5.4.23",
+            "version": "v5.4.24",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "90f21e27d0d88ce38720556dd164d4a1e4c3934c"
+                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/90f21e27d0d88ce38720556dd164d4a1e4c3934c",
-                "reference": "90f21e27d0d88ce38720556dd164d4a1e4c3934c",
+                "url": "https://api.github.com/repos/symfony/console/zipball/560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
+                "reference": "560fc3ed7a43e6d30ea94a07d77f9a60b8ed0fb8",
                 "shasum": ""
             },
             "require": {
@@ -3646,7 +3641,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v5.4.23"
+                "source": "https://github.com/symfony/console/tree/v5.4.24"
             },
             "funding": [
                 {
@@ -3662,7 +3657,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-24T18:47:29+00:00"
+            "time": "2023-05-26T05:13:16+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -3818,25 +3813,25 @@
         },
         {
             "name": "symfony/deprecation-contracts",
-            "version": "v3.2.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/deprecation-contracts.git",
-                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e"
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
-                "reference": "e2d1534420bd723d0ef5aec58a22c5fe60ce6f5e",
+                "url": "https://api.github.com/repos/symfony/deprecation-contracts/zipball/26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
+                "reference": "26954b3d62a6c5fd0ea8a2a00c0353a14978d05c",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1"
+                "php": ">=8.0.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -3865,7 +3860,7 @@
             "description": "A generic function and convention to trigger deprecation notices",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/deprecation-contracts/tree/v3.0.2"
             },
             "funding": [
                 {
@@ -3881,7 +3876,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:25:55+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/dom-crawler",
@@ -4044,20 +4039,20 @@
         },
         {
             "name": "symfony/event-dispatcher-contracts",
-            "version": "v3.2.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher-contracts.git",
-                "reference": "0ad3b6f1e4e2da5690fefe075cd53a238646d8dd"
+                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/0ad3b6f1e4e2da5690fefe075cd53a238646d8dd",
-                "reference": "0ad3b6f1e4e2da5690fefe075cd53a238646d8dd",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher-contracts/zipball/7bc61cc2db649b4637d331240c5346dcc7708051",
+                "reference": "7bc61cc2db649b4637d331240c5346dcc7708051",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.0.2",
                 "psr/event-dispatcher": "^1"
             },
             "suggest": {
@@ -4066,7 +4061,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "3.3-dev"
+                    "dev-main": "3.0-dev"
                 },
                 "thanks": {
                     "name": "symfony/contracts",
@@ -4103,7 +4098,7 @@
                 "standards"
             ],
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.2.1"
+                "source": "https://github.com/symfony/event-dispatcher-contracts/tree/v3.0.2"
             },
             "funding": [
                 {
@@ -4119,7 +4114,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-01T10:32:47+00:00"
+            "time": "2022-01-02T09:55:41+00:00"
         },
         {
             "name": "symfony/filesystem",
@@ -5004,20 +4999,20 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.2.8",
+            "version": "v6.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef"
+                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/193e83bbd6617d6b2151c37fff10fa7168ebddef",
-                "reference": "193e83bbd6617d6b2151c37fff10fa7168ebddef",
+                "url": "https://api.github.com/repos/symfony/string/zipball/d9e72497367c23e08bf94176d2be45b00a9d232a",
+                "reference": "d9e72497367c23e08bf94176d2be45b00a9d232a",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.0.2",
                 "symfony/polyfill-ctype": "~1.8",
                 "symfony/polyfill-intl-grapheme": "~1.0",
                 "symfony/polyfill-intl-normalizer": "~1.0",
@@ -5029,7 +5024,6 @@
             "require-dev": {
                 "symfony/error-handler": "^5.4|^6.0",
                 "symfony/http-client": "^5.4|^6.0",
-                "symfony/intl": "^6.2",
                 "symfony/translation-contracts": "^2.0|^3.0",
                 "symfony/var-exporter": "^5.4|^6.0"
             },
@@ -5070,7 +5064,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.2.8"
+                "source": "https://github.com/symfony/string/tree/v6.0.19"
             },
             "funding": [
                 {
@@ -5086,7 +5080,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-03-20T16:06:02+00:00"
+            "time": "2023-01-01T08:36:10+00:00"
         },
         {
             "name": "symfony/translation",
@@ -5257,20 +5251,20 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v6.2.10",
+            "version": "v6.0.19",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "61916f3861b1e9705b18cfde723921a71dd1559d"
+                "reference": "deec3a812a0305a50db8ae689b183f43d915c884"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/61916f3861b1e9705b18cfde723921a71dd1559d",
-                "reference": "61916f3861b1e9705b18cfde723921a71dd1559d",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/deec3a812a0305a50db8ae689b183f43d915c884",
+                "reference": "deec3a812a0305a50db8ae689b183f43d915c884",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.1",
+                "php": ">=8.0.2",
                 "symfony/polyfill-ctype": "^1.8"
             },
             "conflict": {
@@ -5311,7 +5305,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v6.2.10"
+                "source": "https://github.com/symfony/yaml/tree/v6.0.19"
             },
             "funding": [
                 {
@@ -5327,7 +5321,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2023-04-28T13:25:36+00:00"
+            "time": "2023-01-11T11:50:03+00:00"
         },
         {
             "name": "theseer/tokenizer",
@@ -5492,11 +5486,11 @@
         }
     ],
     "aliases": [],
-    "minimum-stability": "stable",
+    "minimum-stability": "dev",
     "stability-flags": {
         "pantheon-systems/pantheon-wordpress-upstream-tests": 20
     },
-    "prefer-stable": false,
+    "prefer-stable": true,
     "prefer-lowest": false,
     "platform": [],
     "platform-dev": [],


### PR DESCRIPTION
This PR adds the WP.org code analysis tool.
After we checkout the plugin, we also check out the WP.org code analysis tool (really just a PHPCS ruleset) and then run the linter on the current PR.