### PR TITLE
add validate plugin version action

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -69,5 +69,5 @@ jobs:
     name: Validate Plugin Tested Up To Version
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
-      - uses: jazzsequence/action-validate-plugin-version@fix-stuff
+      - uses: actions/checkout@v4
+      - uses: jazzsequence/action-validate-plugin-version@v0

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,6 +7,10 @@ on:
       - synchronize
       - ready_for_review
 
+permissions:
+  pull-requests: write
+  contents: write
+
 jobs:
   lint-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -70,4 +70,4 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: jazzsequence/action-validate-plugin-version@v0
+      - uses: jazzsequence/action-validate-plugin-version@fix-stuff

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -16,7 +16,7 @@ jobs:
       DB_PASSWORD: root
       DB_HOST: localhost
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: Install NPM & Composer dependencies
         run: |
           composer install
@@ -39,7 +39,7 @@ jobs:
     runs-on: ubuntu-latest
     name: WP.org Code Analysis
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - name: WP.org Code Analysis
         uses: pantheon-systems/action-wporg-validator@1.0.0
         with:
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     name: PHP Compatibility
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - run: echo "Note these tests may be incomplete for newer PHP version and miss some deprecations"
         shell: bash
       - name: PHPCompatibility
@@ -61,7 +61,7 @@ jobs:
     name: Validate README Spacing
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: pantheon-systems/validate-readme-spacing@v1
         with:
           filepath: 'README.MD'

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -65,3 +65,9 @@ jobs:
       - uses: pantheon-systems/validate-readme-spacing@v1
         with:
           filepath: 'README.MD'
+  validate-plugin-version:
+    name: Validate Plugin Tested Up To Version
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: jazzsequence/action-validate-plugin-version@v0

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -7,10 +7,6 @@ on:
       - synchronize
       - ready_for_review
 
-permissions:
-  pull-requests: write
-  contents: write
-
 jobs:
   lint-test:
     runs-on: ubuntu-latest
@@ -69,11 +65,3 @@ jobs:
       - uses: pantheon-systems/validate-readme-spacing@v1
         with:
           filepath: 'README.MD'
-  validate-plugin-version:
-    name: Validate Plugin Tested Up To Version
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v4
-      - uses: jazzsequence/action-validate-plugin-version@v1
-        with:
-          filenames: 'readme.txt,README.MD'

--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -74,4 +74,6 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: jazzsequence/action-validate-plugin-version@v0
+      - uses: jazzsequence/action-validate-plugin-version@v1
+        with:
+          filenames: 'readme.txt,README.MD'

--- a/.github/workflows/validate-plugin-version.yml
+++ b/.github/workflows/validate-plugin-version.yml
@@ -1,0 +1,19 @@
+name: Validate Tested Up To Version
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+
+permissions:
+  pull-requests: write
+  contents: write
+
+jobs:
+  validate-plugin-version:
+    runs-on: ubuntu-latest
+    name: Validate Plugin Version
+    steps:
+      - uses: actions/checkout@v4
+      - uses: jazzsequence/action-validate-plugin-version@v1
+        with:
+          filenames: 'readme.txt,README.MD'
+          branch: 'release'


### PR DESCRIPTION
Add `jazzsequence/action-validate-plugin-version` to the pipeline example.

Set as a cron to run once weekly, updated to the latest on the `v1` branch which includes inputs for filenames and branch to base the PR from.