### PR TITLE
[SITE-5879] Playwright BDD PoC for WordPress plugin testing

### DIFF
--- a/.github/workflows/playwright-bdd.yml
+++ b/.github/workflows/playwright-bdd.yml
@@ -1,0 +1,84 @@
+name: Playwright BDD Tests
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'tests/playwright/**'
+      - '.github/workflows/playwright-bdd.yml'
+  pull_request:
+    branches: [main]
+    paths:
+      - 'tests/playwright/**'
+      - '.github/workflows/playwright-bdd.yml'
+  workflow_dispatch:
+    inputs:
+      skip_multidev:
+        description: 'Skip multidev creation (test against existing env)'
+        required: false
+        default: 'true'
+        type: string
+
+jobs:
+  playwright-bdd:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: tests/playwright
+    env:
+      HEADLESS: 'true'
+      TERMINUS_SITE: wp-test-august
+      SKIP_MULTIDEV: ${{ inputs.skip_multidev || 'true' }}
+      WP_URL: https://live-wp-test-august.pantheonsite.io
+      WP_USER: ${{ vars.WP_USER || 'pantheon' }}
+      WP_PASSWORD: ${{ secrets.WP_PASSWORD }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Fetch framework repo
+        uses: actions/checkout@v4
+        with:
+          repository: pantheon-systems/qa-e2e-automation
+          path: qa-e2e-automation
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build framework
+        run: |
+          cd ${{ github.workspace }}/qa-e2e-automation
+          npm install
+          npm run build
+
+      - name: Install dependencies
+        run: |
+          npm pkg set dependencies.qa-e2e-automation-framework="file:${{ github.workspace }}/qa-e2e-automation"
+          npm install
+
+      - name: Install Chromium
+        run: npx playwright install --with-deps chromium
+
+      - name: Generate BDD test specs
+        run: npx bddgen
+
+      - name: Run Playwright BDD tests
+        run: npx playwright test --grep @plugin-pipeline
+
+      - name: Upload test results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: tests/playwright/test-results/
+
+      - name: Upload HTML report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: tests/playwright/playwright-report/

--- a/.github/workflows/playwright-bdd.yml
+++ b/.github/workflows/playwright-bdd.yml
@@ -1,67 +1,59 @@
 name: Playwright BDD Tests
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - 'tests/playwright/**'
-      - '.github/workflows/playwright-bdd.yml'
   pull_request:
     branches: [main]
     paths:
       - 'tests/playwright/**'
       - '.github/workflows/playwright-bdd.yml'
   workflow_dispatch:
-    inputs:
-      skip_multidev:
-        description: 'Skip multidev creation (test against existing env)'
-        required: false
-        default: 'true'
-        type: string
 
 jobs:
   playwright-bdd:
+    name: Playwright BDD Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     defaults:
       run:
         working-directory: tests/playwright
     env:
       HEADLESS: 'true'
       TERMINUS_SITE: wp-test-august
-      SKIP_MULTIDEV: ${{ inputs.skip_multidev || 'true' }}
-      WP_URL: https://live-wp-test-august.pantheonsite.io
-      WP_USER: ${{ vars.WP_USER || 'pantheon' }}
-      WP_PASSWORD: ${{ secrets.WP_PASSWORD }}
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
           node-version: '20'
 
-      - name: Fetch framework repo
-        uses: pantheon-systems/action-fetch-dependency@3deb6f872492dd088f30442c971237e79e881450
+      - name: Install Terminus
+        uses: pantheon-systems/terminus-github-actions@8e024bd89ff46ed2aa4e0663c6b54c87a94344f8 # v1.2.7
         with:
-          repository: pantheon-systems/qa-e2e-automation
-          destination: /tmp/qa-e2e-automation
-          validate-checksum: false
+          pantheon-machine-token: ${{ secrets.TERMINUS_TOKEN }}
+
+      - name: Setup SSH
+        uses: webfactory/ssh-agent@dc588b651fe13675774614f8e6a936a468676387 # v0.9.0
+        with:
+          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY }}
+          log-public-key: true
+
+      - name: Configure SSH
+        run: |
+          mkdir -p ~/.ssh
+          printf "Host *\n  StrictHostKeyChecking no\n  UserKnownHostsFile=/dev/null\n" > ~/.ssh/config
 
       - name: Install dependencies
-        run: |
-          npm pkg set dependencies.qa-e2e-automation-framework="file:/tmp/qa-e2e-automation"
-          npm install
+        run: npm ci
 
       - name: Install Chromium
         run: npx playwright install --with-deps chromium
 
-      - name: Generate BDD test specs
-        run: npx bddgen
-
       - name: Run Playwright BDD tests
-        run: npx playwright test --grep @plugin-pipeline
+        run: npm test
 
       - name: Upload test results
         if: always()

--- a/.github/workflows/playwright-bdd.yml
+++ b/.github/workflows/playwright-bdd.yml
@@ -43,21 +43,15 @@ jobs:
           node-version: '20'
 
       - name: Fetch framework repo
-        uses: actions/checkout@v4
+        uses: pantheon-systems/action-fetch-dependency@3deb6f872492dd088f30442c971237e79e881450
         with:
           repository: pantheon-systems/qa-e2e-automation
-          path: qa-e2e-automation
-          token: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: Build framework
-        run: |
-          cd ${{ github.workspace }}/qa-e2e-automation
-          npm install
-          npm run build
+          destination: /tmp/qa-e2e-automation
+          validate-checksum: false
 
       - name: Install dependencies
         run: |
-          npm pkg set dependencies.qa-e2e-automation-framework="file:${{ github.workspace }}/qa-e2e-automation"
+          npm pkg set dependencies.qa-e2e-automation-framework="file:/tmp/qa-e2e-automation"
           npm install
 
       - name: Install Chromium

--- a/tests/playwright/.env.example
+++ b/tests/playwright/.env.example
@@ -1,0 +1,14 @@
+# WordPress site credentials
+WP_URL=https://live-wp-test-august.pantheonsite.io
+WP_USER=admin
+WP_PASSWORD=
+
+# Pantheon site for multidev provisioning
+TERMINUS_SITE=wp-test-august
+
+# Set to true to skip multidev creation (test against existing env)
+SKIP_MULTIDEV=true
+
+# Browser settings
+HEADLESS=true
+SLOW_MO=0

--- a/tests/playwright/.env.example
+++ b/tests/playwright/.env.example
@@ -1,13 +1,13 @@
-# WordPress site credentials
-WP_URL=https://live-wp-test-august.pantheonsite.io
-WP_USER=admin
-WP_PASSWORD=
-
-# Pantheon site for multidev provisioning
+# Pantheon site for multidev provisioning. global-setup.ts creates a fresh
+# multidev on this site, deploys the plugin, and sets WP_URL/WP_USER/WP_PASSWORD
+# below automatically -- they don't need to be set by hand for a real run.
 TERMINUS_SITE=wp-test-august
 
-# Set to true to skip multidev creation (test against existing env)
-SKIP_MULTIDEV=true
+# WordPress site credentials. Only used if you're running against an existing
+# site manually (e.g. skipping global-setup.ts during local debugging).
+WP_URL=
+WP_USER=pantheon
+WP_PASSWORD=
 
 # Browser settings
 HEADLESS=true

--- a/tests/playwright/.gitignore
+++ b/tests/playwright/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+test-results/
+playwright-report/
+.test-state.json
+.env
+.features-gen/

--- a/tests/playwright/.npmrc
+++ b/tests/playwright/.npmrc
@@ -1,0 +1,1 @@
+install-links=true

--- a/tests/playwright/features/plugin-activation.feature
+++ b/tests/playwright/features/plugin-activation.feature
@@ -1,0 +1,16 @@
+@plugin-pipeline
+Feature: Plugin activation and WordPress admin
+
+  Background:
+    Given I am logged in to the WordPress site
+
+  @activation
+  Scenario: Plugin is listed in the plugins page
+    When I navigate to "/wp-admin/plugins.php"
+    Then I should see "Rossum's Universal Robots"
+
+  @admin
+  Scenario: WordPress dashboard loads correctly
+    When I navigate to "/wp-admin/"
+    Then I should see "Dashboard"
+    And the URL should contain "wp-admin"

--- a/tests/playwright/global-setup.ts
+++ b/tests/playwright/global-setup.ts
@@ -1,86 +1,56 @@
 import * as fs from 'fs';
 import * as path from 'path';
 import { execSync } from 'child_process';
+import {
+  terminusExec,
+  generateMultidevName,
+  getSiteEnv,
+  ensureConnectionMode,
+  waitForWorkflows,
+} from 'cms-bdd';
+import { installBranchPlugin } from './lib/deploy';
 
 const STATE_FILE = path.join(__dirname, '.test-state.json');
-
-function terminusExec(command: string, timeout = 120000): string {
-  return execSync(`terminus ${command}`, {
-    encoding: 'utf-8',
-    timeout,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }).trim();
-}
-
-function generateMultidevName(): string {
-  const id = Math.random().toString(36).substring(2, 7);
-  return `ci-${id}`;
-}
-
-async function waitForWorkflow(siteEnv: string, maxWaitMs = 300000): Promise<void> {
-  const start = Date.now();
-  const pollInterval = 15000;
-  const [siteName, envName] = siteEnv.split('.');
-
-  while (Date.now() - start < maxWaitMs) {
-    try {
-      const output = terminusExec(
-        `workflow:list ${siteName} --fields=workflow,status,env --format=json`,
-        30000
-      );
-      const workflows = JSON.parse(output);
-      const envWorkflows = Object.values(workflows).filter(
-        (w: any) => w.env === envName
-      );
-      const failed = envWorkflows.find((w: any) => w.status === 'failed');
-      if (failed) {
-        throw new Error(`Workflow failed on ${siteEnv}: ${(failed as any).workflow}`);
-      }
-      const running = envWorkflows.find((w: any) => w.status === 'running');
-      if (!running) {
-        console.log('[setup] No running workflows, environment ready');
-        return;
-      }
-      console.log(`[setup] Workflow still running: ${(running as any).workflow}`);
-    } catch (e: any) {
-      if (e.message?.includes('Workflow failed')) throw e;
-    }
-    await new Promise(r => setTimeout(r, pollInterval));
-  }
-  throw new Error(`Timed out waiting for workflows on ${siteEnv}`);
-}
+const ADMIN_USER = 'pantheon';
+const PLUGIN_SLUG = 'rossums-universal-robots';
 
 async function globalSetup(): Promise<void> {
-  if (process.env.SKIP_MULTIDEV === 'true') {
-    console.log('[setup] SKIP_MULTIDEV=true, skipping multidev setup');
-    return;
-  }
-
   const baseSite = process.env.TERMINUS_SITE || 'wp-test-august';
-  console.log(`[setup] Starting WordPress multidev setup for ${baseSite}...`);
 
   const multidevName = generateMultidevName();
-  console.log(`[setup] Creating multidev: ${multidevName}`);
-
+  console.log(`[setup] Creating multidev ${multidevName} on ${baseSite}...`);
   terminusExec(`multidev:create ${baseSite}.dev ${multidevName}`, 600000);
 
-  const siteEnv = `${baseSite}.${multidevName}`;
-  console.log('[setup] Waiting for multidev to be ready...');
-  await waitForWorkflow(siteEnv);
-
   const wpUrl = `https://${multidevName}-${baseSite}.pantheonsite.io`;
+  const siteEnv = getSiteEnv(wpUrl, baseSite);
+
+  console.log('[setup] Waiting for workflows to settle...');
+  // wp-test-august is a shared fixture site, so this can also see workflows
+  // from other repos' concurrent CI runs, not just this multidev's create.
+  await waitForWorkflows(baseSite);
+
+  console.log('[setup] Switching to SFTP and deploying the plugin...');
+  await ensureConnectionMode('sftp', wpUrl);
+  installBranchPlugin(siteEnv);
+
+  console.log('[setup] Activating the plugin and setting a fresh admin password...');
+  const adminPassword = execSync('openssl rand -hex 8').toString().trim();
+  terminusExec(`wp ${siteEnv} -- plugin activate ${PLUGIN_SLUG}`, 60000);
+  terminusExec(`wp ${siteEnv} -- user update ${ADMIN_USER} --user_pass=${adminPassword}`, 60000);
+
+  // Playwright forks test workers after globalSetup returns, so they inherit
+  // these env vars. See the comment on `use.baseURL` in playwright.config.ts
+  // for why step definitions read these directly instead.
   process.env.WP_URL = wpUrl;
+  process.env.WP_USER = ADMIN_USER;
+  process.env.WP_PASSWORD = adminPassword;
 
-  fs.writeFileSync(STATE_FILE, JSON.stringify({
-    multidevName,
-    url: wpUrl,
-    siteEnv,
-    siteName: baseSite,
-  }, null, 2));
+  fs.writeFileSync(
+    STATE_FILE,
+    JSON.stringify({ multidevName, url: wpUrl, siteEnv, siteName: baseSite }, null, 2)
+  );
 
-  console.log(`[setup] WP_URL set to ${wpUrl}`);
-  console.log(`[setup] State written to ${STATE_FILE}`);
-  console.log('[setup] Multidev setup complete');
+  console.log(`[setup] Multidev ready at ${wpUrl}`);
 }
 
 export default globalSetup;

--- a/tests/playwright/global-setup.ts
+++ b/tests/playwright/global-setup.ts
@@ -1,0 +1,86 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const STATE_FILE = path.join(__dirname, '.test-state.json');
+
+function terminusExec(command: string, timeout = 120000): string {
+  return execSync(`terminus ${command}`, {
+    encoding: 'utf-8',
+    timeout,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+function generateMultidevName(): string {
+  const id = Math.random().toString(36).substring(2, 7);
+  return `ci-${id}`;
+}
+
+async function waitForWorkflow(siteEnv: string, maxWaitMs = 300000): Promise<void> {
+  const start = Date.now();
+  const pollInterval = 15000;
+  const [siteName, envName] = siteEnv.split('.');
+
+  while (Date.now() - start < maxWaitMs) {
+    try {
+      const output = terminusExec(
+        `workflow:list ${siteName} --fields=workflow,status,env --format=json`,
+        30000
+      );
+      const workflows = JSON.parse(output);
+      const envWorkflows = Object.values(workflows).filter(
+        (w: any) => w.env === envName
+      );
+      const failed = envWorkflows.find((w: any) => w.status === 'failed');
+      if (failed) {
+        throw new Error(`Workflow failed on ${siteEnv}: ${(failed as any).workflow}`);
+      }
+      const running = envWorkflows.find((w: any) => w.status === 'running');
+      if (!running) {
+        console.log('[setup] No running workflows, environment ready');
+        return;
+      }
+      console.log(`[setup] Workflow still running: ${(running as any).workflow}`);
+    } catch (e: any) {
+      if (e.message?.includes('Workflow failed')) throw e;
+    }
+    await new Promise(r => setTimeout(r, pollInterval));
+  }
+  throw new Error(`Timed out waiting for workflows on ${siteEnv}`);
+}
+
+async function globalSetup(): Promise<void> {
+  if (process.env.SKIP_MULTIDEV === 'true') {
+    console.log('[setup] SKIP_MULTIDEV=true, skipping multidev setup');
+    return;
+  }
+
+  const baseSite = process.env.TERMINUS_SITE || 'wp-test-august';
+  console.log(`[setup] Starting WordPress multidev setup for ${baseSite}...`);
+
+  const multidevName = generateMultidevName();
+  console.log(`[setup] Creating multidev: ${multidevName}`);
+
+  terminusExec(`multidev:create ${baseSite}.dev ${multidevName}`, 600000);
+
+  const siteEnv = `${baseSite}.${multidevName}`;
+  console.log('[setup] Waiting for multidev to be ready...');
+  await waitForWorkflow(siteEnv);
+
+  const wpUrl = `https://${multidevName}-${baseSite}.pantheonsite.io`;
+  process.env.WP_URL = wpUrl;
+
+  fs.writeFileSync(STATE_FILE, JSON.stringify({
+    multidevName,
+    url: wpUrl,
+    siteEnv,
+    siteName: baseSite,
+  }, null, 2));
+
+  console.log(`[setup] WP_URL set to ${wpUrl}`);
+  console.log(`[setup] State written to ${STATE_FILE}`);
+  console.log('[setup] Multidev setup complete');
+}
+
+export default globalSetup;

--- a/tests/playwright/global-teardown.ts
+++ b/tests/playwright/global-teardown.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import { execSync } from 'child_process';
+
+const STATE_FILE = path.join(__dirname, '.test-state.json');
+
+function terminusExec(command: string, timeout = 120000): string {
+  return execSync(`terminus ${command}`, {
+    encoding: 'utf-8',
+    timeout,
+    stdio: ['pipe', 'pipe', 'pipe'],
+  }).trim();
+}
+
+async function globalTeardown(): Promise<void> {
+  if (process.env.SKIP_MULTIDEV === 'true') {
+    console.log('[teardown] SKIP_MULTIDEV=true, skipping cleanup');
+    return;
+  }
+
+  try {
+    const raw = fs.readFileSync(STATE_FILE, 'utf-8');
+    const state = JSON.parse(raw);
+
+    if (state.siteName && state.multidevName) {
+      console.log(`[teardown] Deleting multidev: ${state.siteName}.${state.multidevName}`);
+      terminusExec(
+        `multidev:delete ${state.siteName}.${state.multidevName} --delete-branch -y`,
+        120000
+      );
+      console.log('[teardown] Multidev deleted');
+    }
+
+    fs.unlinkSync(STATE_FILE);
+  } catch (e: any) {
+    console.log(`[teardown] Cleanup error (non-fatal): ${e.message}`);
+  }
+}
+
+export default globalTeardown;

--- a/tests/playwright/global-teardown.ts
+++ b/tests/playwright/global-teardown.ts
@@ -1,33 +1,17 @@
 import * as fs from 'fs';
 import * as path from 'path';
-import { execSync } from 'child_process';
+import { terminusExec } from 'cms-bdd';
 
 const STATE_FILE = path.join(__dirname, '.test-state.json');
 
-function terminusExec(command: string, timeout = 120000): string {
-  return execSync(`terminus ${command}`, {
-    encoding: 'utf-8',
-    timeout,
-    stdio: ['pipe', 'pipe', 'pipe'],
-  }).trim();
-}
-
 async function globalTeardown(): Promise<void> {
-  if (process.env.SKIP_MULTIDEV === 'true') {
-    console.log('[teardown] SKIP_MULTIDEV=true, skipping cleanup');
-    return;
-  }
-
   try {
     const raw = fs.readFileSync(STATE_FILE, 'utf-8');
     const state = JSON.parse(raw);
 
     if (state.siteName && state.multidevName) {
       console.log(`[teardown] Deleting multidev: ${state.siteName}.${state.multidevName}`);
-      terminusExec(
-        `multidev:delete ${state.siteName}.${state.multidevName} --delete-branch -y`,
-        120000
-      );
+      terminusExec(`multidev:delete ${state.siteName}.${state.multidevName} --delete-branch -y`, 120000);
       console.log('[teardown] Multidev deleted');
     }
 

--- a/tests/playwright/lib/deploy.ts
+++ b/tests/playwright/lib/deploy.ts
@@ -1,0 +1,51 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+import { terminusExec } from 'cms-bdd';
+
+// cms-bdd covers multidev create/delete, connection-mode switching, and
+// workflow polling. It doesn't ship an SFTP file-push helper, since that's
+// specific to each consumer's plugin/module layout -- adapted here from the
+// working pattern in pantheon-mu-plugin PR #119 (tests/e2e/lib/pantheon.ts).
+
+const PLUGIN_SLUG = 'rossums-universal-robots';
+const REMOTE_PLUGIN_DIR = `code/wp-content/plugins/${PLUGIN_SLUG}`;
+
+// Repo root, so sftp `put` commands can use plain repo-relative local paths
+// regardless of the Playwright process's own working directory.
+const REPO_ROOT = path.resolve(__dirname, '..', '..', '..');
+
+function assertSafeName(kind: string, value: string): string {
+  if (!/^[a-z0-9][a-z0-9.-]*$/i.test(value)) {
+    throw new Error(`Unsafe ${kind}: ${JSON.stringify(value)}`);
+  }
+  return value;
+}
+
+/** Run a batch of sftp commands against a site.env (non-interactive). */
+function sftpBatch(siteEnv: string, commands: string[]): void {
+  assertSafeName('site.env', siteEnv);
+  const sftpCmd = terminusExec(`connection:info ${siteEnv} --field=sftp_command`, 60000).trim();
+  const sftpWithOpts = sftpCmd.replace(
+    /^sftp /,
+    'sftp -o StrictHostKeyChecking=no -o UserKnownHostsFile=/dev/null -b - '
+  );
+  execSync(sftpWithOpts, {
+    cwd: REPO_ROOT,
+    input: [...commands, 'bye'].join('\n'),
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 120000,
+  });
+}
+
+/**
+ * SFTP the plugin's release files (the same files .distignore keeps for the
+ * WordPress.org package -- see build-tag-release.yml) onto a fresh multidev.
+ */
+export function installBranchPlugin(siteEnv: string): void {
+  sftpBatch(siteEnv, [
+    `mkdir ${REMOTE_PLUGIN_DIR}`,
+    `put rossums-universal-robots.php ${REMOTE_PLUGIN_DIR}/rossums-universal-robots.php`,
+    `put readme.txt ${REMOTE_PLUGIN_DIR}/readme.txt`,
+    `put -r assets ${REMOTE_PLUGIN_DIR}/assets`,
+  ]);
+}

--- a/tests/playwright/package-lock.json
+++ b/tests/playwright/package-lock.json
@@ -1,0 +1,818 @@
+{
+  "name": "plugin-pipeline-playwright-bdd-poc",
+  "version": "1.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "plugin-pipeline-playwright-bdd-poc",
+      "version": "1.0.0",
+      "dependencies": {
+        "cms-bdd": "github:pantheon-systems/cms-bdd",
+        "dotenv": "^16.4.0"
+      },
+      "devDependencies": {
+        "@playwright/test": "1.60.0",
+        "@types/node": "^20.19.39",
+        "playwright": "1.60.0",
+        "playwright-bdd": "8.5.1",
+        "typescript": "^5.9.0"
+      }
+    },
+    "node_modules/@colors/colors": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/@colors/colors/-/colors-1.5.0.tgz",
+      "integrity": "sha512-ooWCrlZP11i8GImSjTHYHLkvFDP48nS4+204nGb1RiX/WXYHmJA2III9/e2DWVabCESdW7hBAEzHRqUn9OUVvQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.1.90"
+      }
+    },
+    "node_modules/@cucumber/cucumber-expressions": {
+      "version": "18.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/cucumber-expressions/-/cucumber-expressions-18.0.1.tgz",
+      "integrity": "sha512-NSid6bI+7UlgMywl5octojY5NXnxR9uq+JisjOrO52VbFsQM6gTWuQFE8syI10KnIBEdPzuEUSVEeZ0VFzRnZA==",
+      "license": "MIT",
+      "dependencies": {
+        "regexp-match-indices": "1.0.2"
+      }
+    },
+    "node_modules/@cucumber/gherkin": {
+      "version": "32.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-32.2.0.tgz",
+      "integrity": "sha512-X8xuVhSIqlUjxSRifRJ7t0TycVWyX58fygJH3wDNmHINLg9sYEkvQT0SO2G5YlRZnYc11TIFr4YPenscvdlBIw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=19.1.4 <28"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils": {
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin-utils/-/gherkin-utils-9.2.0.tgz",
+      "integrity": "sha512-3nmRbG1bUAZP3fAaUBNmqWO0z0OSkykZZotfLjyhc8KWwDSOrOmMJlBTd474lpA8EWh4JFLAX3iXgynBqBvKzw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/gherkin": "^31.0.0",
+        "@cucumber/messages": "^27.0.0",
+        "@teppeis/multimaps": "3.0.0",
+        "commander": "13.1.0",
+        "source-map-support": "^0.5.21"
+      },
+      "bin": {
+        "gherkin-utils": "bin/gherkin-utils"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin": {
+      "version": "31.0.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/gherkin/-/gherkin-31.0.0.tgz",
+      "integrity": "sha512-wlZfdPif7JpBWJdqvHk1Mkr21L5vl4EfxVUOS4JinWGf3FLRV6IKUekBv5bb5VX79fkDcfDvESzcQ8WQc07Wgw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/messages": ">=19.1.4 <=26"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/@cucumber/gherkin/node_modules/@cucumber/messages": {
+      "version": "26.0.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-26.0.1.tgz",
+      "integrity": "sha512-DIxSg+ZGariumO+Lq6bn4kOUIUET83A4umrnWmidjGFl8XxkBieUZtsmNbLYgH/gnsmP07EfxxdTr0hOchV1Sg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "10.0.0"
+      }
+    },
+    "node_modules/@cucumber/gherkin-utils/node_modules/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-8XkAphELsDnEGrDxUOHB3RGvXz6TeuYSGEZBOjtTtPm2lwhGBjLgOzLHB63IUWfBpNucQjND6d3AOudO+H3RWQ==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/bin/uuid"
+      }
+    },
+    "node_modules/@cucumber/html-formatter": {
+      "version": "21.15.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/html-formatter/-/html-formatter-21.15.1.tgz",
+      "integrity": "sha512-tjxEpP161sQ7xc3VREc94v1ymwIckR3ySViy7lTvfi1jUpyqy2Hd/p4oE3YT1kQ9fFDvUflPwu5ugK5mA7BQLA==",
+      "license": "MIT",
+      "peerDependencies": {
+        "@cucumber/messages": ">=18"
+      }
+    },
+    "node_modules/@cucumber/junit-xml-formatter": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/@cucumber/junit-xml-formatter/-/junit-xml-formatter-0.7.1.tgz",
+      "integrity": "sha512-AzhX+xFE/3zfoYeqkT7DNq68wAQfBcx4Dk9qS/ocXM2v5tBv6eFQ+w8zaSfsktCjYzu4oYRH/jh4USD1CYHfaQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/query": "^13.0.2",
+        "@teppeis/multimaps": "^3.0.0",
+        "luxon": "^3.5.0",
+        "xmlbuilder": "^15.1.1"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
+      }
+    },
+    "node_modules/@cucumber/messages": {
+      "version": "27.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/messages/-/messages-27.2.0.tgz",
+      "integrity": "sha512-f2o/HqKHgsqzFLdq6fAhfG1FNOQPdBdyMGpKwhb7hZqg0yZtx9BVqkTyuoNk83Fcvk3wjMVfouFXXHNEk4nddA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/uuid": "10.0.0",
+        "class-transformer": "0.5.1",
+        "reflect-metadata": "0.2.2",
+        "uuid": "11.0.5"
+      }
+    },
+    "node_modules/@cucumber/query": {
+      "version": "13.6.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/query/-/query-13.6.0.tgz",
+      "integrity": "sha512-tiDneuD5MoWsJ9VKPBmQok31mSX9Ybl+U4wqDoXeZgsXHDURqzM3rnpWVV3bC34y9W6vuFxrlwF/m7HdOxwqRw==",
+      "license": "MIT",
+      "dependencies": {
+        "@teppeis/multimaps": "3.0.0",
+        "lodash.sortby": "^4.7.0"
+      },
+      "peerDependencies": {
+        "@cucumber/messages": "*"
+      }
+    },
+    "node_modules/@cucumber/tag-expressions": {
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/@cucumber/tag-expressions/-/tag-expressions-6.2.0.tgz",
+      "integrity": "sha512-KIF0eLcafHbWOuSDWFw0lMmgJOLdDRWjEL1kfXEWrqHmx2119HxVAr35WuEd9z542d3Yyg+XNqSr+81rIKqEdg==",
+      "license": "MIT"
+    },
+    "node_modules/@nodelib/fs.scandir": {
+      "version": "2.1.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
+      "integrity": "sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "2.0.5",
+        "run-parallel": "^1.1.9"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.stat": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.5.tgz",
+      "integrity": "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@nodelib/fs.walk": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.8.tgz",
+      "integrity": "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.scandir": "2.1.5",
+        "fastq": "^1.6.0"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.60.0.tgz",
+      "integrity": "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@teppeis/multimaps": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@teppeis/multimaps/-/multimaps-3.0.0.tgz",
+      "integrity": "sha512-ID7fosbc50TbT0MK0EG12O+gAP3W3Aa/Pz4DaTtQtEvlc9Odaqi0de+xuZ7Li2GtK4HzEX7IuRWS/JmZLksR3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/@types/node": {
+      "version": "20.19.43",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.43.tgz",
+      "integrity": "sha512-6oYBAi5ikg4Pl+kGsoYtawUMBT2zZMCvPNF7pVLnHZfd1zf38DRiWn/gT01RYCdUqkv7Fhr+C9ot4/tb+2sVvA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
+    },
+    "node_modules/@types/uuid": {
+      "version": "10.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-10.0.0.tgz",
+      "integrity": "sha512-7gqG38EyHgyP1S+7+xomFtL+ZNHcKv6DwNaCZmJmo1vgMugyF3TCnXVg4t1uk89mLNwnLtnY3TpOpCOyp1/xHQ==",
+      "license": "MIT"
+    },
+    "node_modules/allure-js-commons": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/allure-js-commons/-/allure-js-commons-3.10.2.tgz",
+      "integrity": "sha512-5nAjUF1iNPSQMwKtEsadclSta8C3L705/k/pIzGb9M6P9krgfRaCyaEHt8pkLlCP9NFj5xk3grjtnAhiLeT+Kg==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "md5": "^2.3.0"
+      },
+      "peerDependencies": {
+        "allure-playwright": "3.10.2"
+      },
+      "peerDependenciesMeta": {
+        "allure-playwright": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/allure-playwright": {
+      "version": "3.10.2",
+      "resolved": "https://registry.npmjs.org/allure-playwright/-/allure-playwright-3.10.2.tgz",
+      "integrity": "sha512-CGyhxSvx2bIkojhBy0pbQZ12vkLbOE3FBh39WgzPs+katwnuGPUE0whJhryG8aD/dlDALxMehL9G0k8WYBx4tQ==",
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "allure-js-commons": "3.10.2"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.53.0"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/braces": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/braces/-/braces-3.0.3.tgz",
+      "integrity": "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==",
+      "license": "MIT",
+      "dependencies": {
+        "fill-range": "^7.1.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/buffer-from": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
+      "license": "MIT"
+    },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/class-transformer": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/class-transformer/-/class-transformer-0.5.1.tgz",
+      "integrity": "sha512-SQa1Ws6hUbfC98vKGxZH3KFY0Y1lm5Zm0SY8XX9zbK7FJCyVEac3ATW0RIpwzW+oOfmHE5PMPufDG9hCfoEOMw==",
+      "license": "MIT"
+    },
+    "node_modules/cli-table3": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/cli-table3/-/cli-table3-0.6.5.tgz",
+      "integrity": "sha512-+W/5efTR7y5HRD7gACw9yQjqMVvEMLBHmboM/kPWam+H+Hmyrgjh6YncVKK122YZkXrLudzTuAukUw9FnMf7IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "string-width": "^4.2.0"
+      },
+      "engines": {
+        "node": "10.* || >= 12.*"
+      },
+      "optionalDependencies": {
+        "@colors/colors": "1.5.0"
+      }
+    },
+    "node_modules/cms-bdd": {
+      "version": "1.0.0",
+      "resolved": "git+ssh://git@github.com/pantheon-systems/cms-bdd.git#8a2139346b48d15d2306ea1d2c49ade20ef22c28",
+      "license": "ISC",
+      "dependencies": {
+        "dotenv-flow": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@playwright/test": "^1.60.0",
+        "allure-playwright": "^3.0.0",
+        "playwright": "^1.60.0",
+        "playwright-bdd": "^8.5.1"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "engines": {
+        "node": "*"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
+      }
+    },
+    "node_modules/dotenv-flow": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/dotenv-flow/-/dotenv-flow-4.1.0.tgz",
+      "integrity": "sha512-0cwP9jpQBQfyHwvE0cRhraZMkdV45TQedA8AAUZMsFzvmLcQyc1HPv+oX0OOYwLFjIlvgVepQ+WuQHbqDaHJZg==",
+      "license": "MIT",
+      "dependencies": {
+        "dotenv": "^16.0.0"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      }
+    },
+    "node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
+      "license": "MIT"
+    },
+    "node_modules/fast-glob": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.3.3.tgz",
+      "integrity": "sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==",
+      "license": "MIT",
+      "dependencies": {
+        "@nodelib/fs.stat": "^2.0.2",
+        "@nodelib/fs.walk": "^1.2.3",
+        "glob-parent": "^5.1.2",
+        "merge2": "^1.3.0",
+        "micromatch": "^4.0.8"
+      },
+      "engines": {
+        "node": ">=8.6.0"
+      }
+    },
+    "node_modules/fastq": {
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
+      "license": "ISC",
+      "dependencies": {
+        "reusify": "^1.0.4"
+      }
+    },
+    "node_modules/fill-range": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
+      "integrity": "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==",
+      "license": "MIT",
+      "dependencies": {
+        "to-regex-range": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/glob-parent": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.2.tgz",
+      "integrity": "sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==",
+      "license": "ISC",
+      "dependencies": {
+        "is-glob": "^4.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/is-extglob": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
+      "integrity": "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-fullwidth-code-point": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+      "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/is-glob": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.3.tgz",
+      "integrity": "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==",
+      "license": "MIT",
+      "dependencies": {
+        "is-extglob": "^2.1.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-number": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
+      "integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.12.0"
+      }
+    },
+    "node_modules/lodash.sortby": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/lodash.sortby/-/lodash.sortby-4.7.0.tgz",
+      "integrity": "sha512-HDWXG8isMntAyRF5vZ7xKuEvOhT4AhlRt/3czTSjvGUxjYCBVRQY48ViDHyfYz9VIoBkW4TMGQNapx+l3RUwdA==",
+      "license": "MIT"
+    },
+    "node_modules/luxon": {
+      "version": "3.7.2",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-3.7.2.tgz",
+      "integrity": "sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "license": "BSD-3-Clause",
+      "peer": true,
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
+      }
+    },
+    "node_modules/merge2": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/merge2/-/merge2-1.4.1.tgz",
+      "integrity": "sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 8"
+      }
+    },
+    "node_modules/micromatch": {
+      "version": "4.0.8",
+      "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.8.tgz",
+      "integrity": "sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==",
+      "license": "MIT",
+      "dependencies": {
+        "braces": "^3.0.3",
+        "picomatch": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.54.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.54.0.tgz",
+      "integrity": "sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-3.0.2.tgz",
+      "integrity": "sha512-Lbgzdk0h4juoQ9fCKXW4by0UJqj+nOOrI9MJ1sSj4nI8aI2eo1qmvQEie4VD1glsS250n15LsWsYtCugiStS5A==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "^1.54.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/picomatch": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.6"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.60.0.tgz",
+      "integrity": "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.60.0"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-bdd": {
+      "version": "8.5.1",
+      "resolved": "https://registry.npmjs.org/playwright-bdd/-/playwright-bdd-8.5.1.tgz",
+      "integrity": "sha512-lDNaDzW8RvbvsKuR8cZaP9LBnRbG9juCOE3tgwm3pr1O0W1ooGPz7X8xH7zdUbqGgHbdOQ+5XpUTlOJrvpY6Tw==",
+      "license": "MIT",
+      "dependencies": {
+        "@cucumber/cucumber-expressions": "18.0.1",
+        "@cucumber/gherkin": "^32.1.2",
+        "@cucumber/gherkin-utils": "^9.2.0",
+        "@cucumber/html-formatter": "^21.11.0",
+        "@cucumber/junit-xml-formatter": "^0.7.1",
+        "@cucumber/messages": "^27.2.0",
+        "@cucumber/tag-expressions": "^6.2.0",
+        "cli-table3": "0.6.5",
+        "commander": "^13.1.0",
+        "fast-glob": "^3.3.3",
+        "mime-types": "^3.0.2",
+        "xmlbuilder": "15.1.1"
+      },
+      "bin": {
+        "bddgen": "dist/cli/index.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/vitalets"
+      },
+      "peerDependencies": {
+        "@playwright/test": ">=1.44"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.60.0",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.60.0.tgz",
+      "integrity": "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA==",
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/queue-microtask": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
+      "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/reflect-metadata": {
+      "version": "0.2.2",
+      "resolved": "https://registry.npmjs.org/reflect-metadata/-/reflect-metadata-0.2.2.tgz",
+      "integrity": "sha512-urBwgfrvVP/eAyXx4hluJivBKzuEbSQs9rKWCrCkbSxNv8mxPcUZKeuoF3Uy4mJl3Lwprp6yy5/39VWigZ4K6Q==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/regexp-match-indices": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/regexp-match-indices/-/regexp-match-indices-1.0.2.tgz",
+      "integrity": "sha512-DwZuAkt8NF5mKwGGER1EGh2PRqyvhRhhLviH+R8y8dIuaQROlUfXjt4s9ZTXstIsSkptf06BSvwcEmmfheJJWQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "regexp-tree": "^0.1.11"
+      }
+    },
+    "node_modules/regexp-tree": {
+      "version": "0.1.27",
+      "resolved": "https://registry.npmjs.org/regexp-tree/-/regexp-tree-0.1.27.tgz",
+      "integrity": "sha512-iETxpjK6YoRWJG5o6hXLwvjYAoW+FEZn9os0PD/b6AP6xQwsa/Y7lCVgIixBbUPMfhu+i2LtdeAqVTgGlQarfA==",
+      "license": "MIT",
+      "bin": {
+        "regexp-tree": "bin/regexp-tree"
+      }
+    },
+    "node_modules/reusify": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/reusify/-/reusify-1.1.0.tgz",
+      "integrity": "sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==",
+      "license": "MIT",
+      "engines": {
+        "iojs": ">=1.0.0",
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/run-parallel": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.2.0.tgz",
+      "integrity": "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "queue-microtask": "^1.2.2"
+      }
+    },
+    "node_modules/source-map": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/source-map-support": {
+      "version": "0.5.21",
+      "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.21.tgz",
+      "integrity": "sha512-uBHU3L3czsIyYXKX88fdrGovxdSCoTGDRZ6SYXtSRxLZUzHg5P/66Ht6uoUlHu9EZod+inXhKo3qQgwXUT/y1w==",
+      "license": "MIT",
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "source-map": "^0.6.0"
+      }
+    },
+    "node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "license": "MIT",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "license": "MIT",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/to-regex-range": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
+      "integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+      "license": "MIT",
+      "dependencies": {
+        "is-number": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/uuid": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.0.5.tgz",
+      "integrity": "sha512-508e6IcKLrhxKdBbcA2b4KQZlLVp2+J5UwQ6F7Drckkc5N9ZJwFa4TgWtsww9UG8fGHbm6gbV19TdM5pQ4GaIA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "license": "MIT",
+      "bin": {
+        "uuid": "dist/esm/bin/uuid"
+      }
+    },
+    "node_modules/xmlbuilder": {
+      "version": "15.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-15.1.1.tgz",
+      "integrity": "sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8.0"
+      }
+    }
+  }
+}

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -1,0 +1,24 @@
+{
+  "name": "plugin-pipeline-playwright-bdd-poc",
+  "version": "1.0.0",
+  "description": "Playwright BDD PoC for SiteX WordPress plugin testing (SITE-5879)",
+  "private": true,
+  "scripts": {
+    "test": "bddgen && playwright test",
+    "test:headed": "bddgen && HEADLESS=false playwright test",
+    "test:debug": "bddgen && playwright test --debug",
+    "test:ui": "bddgen && playwright test --ui",
+    "test:report": "playwright show-report",
+    "bddgen": "bddgen"
+  },
+  "dependencies": {
+    "dotenv": "^16.4.0",
+    "qa-e2e-automation-framework": "file:../../../qa-e2e-automation"
+  },
+  "devDependencies": {
+    "@playwright/test": "1.60.0",
+    "playwright": "1.60.0",
+    "playwright-bdd": "8.5.1",
+    "typescript": "^5.9.0"
+  }
+}

--- a/tests/playwright/package.json
+++ b/tests/playwright/package.json
@@ -12,13 +12,14 @@
     "bddgen": "bddgen"
   },
   "dependencies": {
-    "dotenv": "^16.4.0",
-    "qa-e2e-automation-framework": "file:../../../qa-e2e-automation"
+    "cms-bdd": "github:pantheon-systems/cms-bdd",
+    "dotenv": "^16.4.0"
   },
   "devDependencies": {
     "@playwright/test": "1.60.0",
     "playwright": "1.60.0",
     "playwright-bdd": "8.5.1",
-    "typescript": "^5.9.0"
+    "typescript": "^5.9.0",
+    "@types/node": "^20.19.39"
   }
 }

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -7,9 +7,8 @@ dotenv.config();
 const testDir = defineBddConfig({
   features: 'features/**/*.feature',
   steps: [
-    'node_modules/qa-e2e-automation-framework/dist/steps/ui/**/*.js',
-    'node_modules/qa-e2e-automation-framework/dist/steps/backend/**/*.js',
-    'node_modules/qa-e2e-automation-framework/dist/fixtures/customFixtures.js',
+    'steps/**/*.ts',
+    'node_modules/cms-bdd/dist/fixtures/customFixtures.js',
   ],
 });
 
@@ -30,14 +29,23 @@ export default defineConfig({
   ],
   timeout: 300000,
   use: {
-    baseURL: process.env.WP_URL || 'https://live-wp-test-august.pantheonsite.io',
+    // Local-dev convenience only. This is resolved once when the config module
+    // loads, before globalSetup creates the multidev, so it's frozen at whatever
+    // WP_URL was set at process start. Step definitions read `process.env.WP_URL`
+    // directly at call time instead of relying on Playwright's baseURL resolution,
+    // since globalSetup updates that env var (and Playwright forks test workers
+    // after globalSetup runs, so they inherit the updated value) but this frozen
+    // config value would not reflect it.
+    baseURL: process.env.WP_URL,
     headless,
     launchOptions: {
       slowMo,
     },
     trace: 'on-first-retry',
     screenshot: 'only-on-failure',
-    video: 'retain-on-failure',
+    // Always record, not just on failure -- the spike's acceptance criterion is
+    // "test execution is recorded as a video", not "on failure only".
+    video: 'on',
     actionTimeout: 10000,
     navigationTimeout: 30000,
   },

--- a/tests/playwright/playwright.config.ts
+++ b/tests/playwright/playwright.config.ts
@@ -1,0 +1,53 @@
+import { defineConfig, devices } from '@playwright/test';
+import { defineBddConfig } from 'playwright-bdd';
+import * as dotenv from 'dotenv';
+
+dotenv.config();
+
+const testDir = defineBddConfig({
+  features: 'features/**/*.feature',
+  steps: [
+    'node_modules/qa-e2e-automation-framework/dist/steps/ui/**/*.js',
+    'node_modules/qa-e2e-automation-framework/dist/steps/backend/**/*.js',
+    'node_modules/qa-e2e-automation-framework/dist/fixtures/customFixtures.js',
+  ],
+});
+
+const headless = process.env.HEADLESS !== 'false';
+const slowMo = parseInt(process.env.SLOW_MO || '0');
+
+export default defineConfig({
+  globalSetup: './global-setup.ts',
+  globalTeardown: './global-teardown.ts',
+  testDir,
+  fullyParallel: false,
+  forbidOnly: !!process.env.CI,
+  retries: process.env.CI ? 2 : 0,
+  workers: 1,
+  reporter: [
+    ['html'],
+    ['list'],
+  ],
+  timeout: 300000,
+  use: {
+    baseURL: process.env.WP_URL || 'https://live-wp-test-august.pantheonsite.io',
+    headless,
+    launchOptions: {
+      slowMo,
+    },
+    trace: 'on-first-retry',
+    screenshot: 'only-on-failure',
+    video: 'retain-on-failure',
+    actionTimeout: 10000,
+    navigationTimeout: 30000,
+  },
+  projects: [
+    {
+      name: 'chromium',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1920, height: 1080 },
+      },
+    },
+  ],
+});

--- a/tests/playwright/steps/plugin-activation.steps.ts
+++ b/tests/playwright/steps/plugin-activation.steps.ts
@@ -1,0 +1,23 @@
+import { createBdd } from 'playwright-bdd';
+import { test, expect } from 'cms-bdd';
+
+const { Given, When, Then } = createBdd(test);
+
+Given('I am logged in to the WordPress site', async ({ wpLoginPage }) => {
+  await wpLoginPage.login();
+});
+
+// Built from process.env.WP_URL directly (set by global-setup.ts once the
+// multidev exists) rather than Playwright's baseURL, which is frozen at
+// config-load time before the multidev is created -- see playwright.config.ts.
+When('I navigate to {string}', async ({ page }, path: string) => {
+  await page.goto(`${process.env.WP_URL}${path}`);
+});
+
+Then('I should see {string}', async ({ page }, text: string) => {
+  await expect(page.locator('body')).toContainText(text);
+});
+
+Then('the URL should contain {string}', async ({ page }, fragment: string) => {
+  expect(page.url()).toContain(fragment);
+});

--- a/tests/playwright/tsconfig.json
+++ b/tests/playwright/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ESNext",
+    "module": "commonjs",
+    "moduleResolution": "node",
+    "esModuleInterop": true,
+    "strict": true,
+    "skipLibCheck": true,
+    "resolveJsonModule": true,
+    "types": ["node", "@playwright/test"]
+  },
+  "include": ["**/*.ts"],
+  "exclude": ["node_modules", ".features-gen"]
+}


### PR DESCRIPTION
## Summary

[SITE-5879](https://getpantheon.atlassian.net/browse/SITE-5879): Proof of concept for using Playwright BDD as a replacement for Behat in SiteX plugin/module testing.

Uses Ander's [qa-e2e-automation](https://github.com/pantheon-systems/qa-e2e-automation) framework with [playwright-bdd](https://github.com/vitalets/playwright-bdd) for Gherkin feature files. Tests run against wp-test-august on Cloudflare GCDN.

### What's included

- Playwright BDD config and feature file with two scenarios (plugin activation, dashboard load)
- Global setup/teardown for multidev provisioning (skippable for local dev)
- GitHub Actions CI workflow
- Uses real Chromium browser (vs Behat's Goutte/BrowserKit HTTP client)

### Why this matters

Behat fails on Cloudflare-migrated fixture sites because Goutte can't handle bot protection challenges ([SITE-5429](https://getpantheon.atlassian.net/browse/SITE-5429), [EDRT-9550](https://getpantheon.atlassian.net/browse/EDRT-9550)). Playwright uses real Chromium which may handle these challenges.

## Test plan

- [ ] CI workflow runs successfully
- [ ] Playwright BDD tests pass against wp-test-august (Cloudflare)
- [ ] Video recording artifact is produced

[SITE-5879]: https://getpantheon.atlassian.net/browse/SITE-5879?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[SITE-5429]: https://getpantheon.atlassian.net/browse/SITE-5429?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[EDRT-9550]: https://getpantheon.atlassian.net/browse/EDRT-9550?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ